### PR TITLE
Improving initial page loading time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal
+
 /db/seeds.rb
 
 # Ignore schema_cache.dump
@@ -32,6 +33,8 @@ vendor/
 node_modules/
 # Ignore application configuration
 /config/application.yml
+/config/newrelic.yml
+/config/initializers/bullet.rb
 /config/initializers/rack_profiler.rb
 
 .env.*

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'pg', '0.21.0'
 # Heroku email service
 gem 'postmark-rails', '0.15.0'
 # Use Puma as the web server
-gem 'puma', '2.16.0'
+gem 'puma', '3.11.3'
 gem 'pundit', '1.1.0'
 # Limits processing time in rack layer for added loading protection
 gem 'rack-timeout', '0.4.2'
@@ -72,6 +72,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', '9.1.0'
   gem 'derailed_benchmarks', '~> 1.3', '>= 1.3.2'
+  gem 'newrelic_rpm', '~> 5.4', '>= 5.4.0.347'
   gem 'pry-rails', '~> 0.3.6'
   gem 'stackprof', group: :development
   gem 'sys-proctable', platforms: [:mingw, :mswin, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
     mono_logger (1.1.0)
     multi_json (1.13.1)
     mustermann (1.0.2)
+    newrelic_rpm (5.4.0.347)
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
@@ -161,7 +162,7 @@ GEM
       method_source (~> 0.9.0)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
-    puma (2.16.0)
+    puma (3.11.3)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     rack (2.0.5)
@@ -325,12 +326,13 @@ DEPENDENCIES
   jquery-rails (= 4.3.1)
   json (= 1.8.6)
   minitest (= 5.10.3, != 5.10.2)
+  newrelic_rpm (~> 5.4, >= 5.4.0.347)
   oj (= 3.3.9)
   parallel (= 1.12.0)
   pg (= 0.21.0)
   postmark-rails (= 0.15.0)
   pry-rails (~> 0.3.6)
-  puma (= 2.16.0)
+  puma (= 3.11.3)
   pundit (= 1.1.0)
   rack-mini-profiler
   rack-timeout (= 0.4.2)
@@ -357,4 +359,4 @@ RUBY VERSION
    ruby 2.5.0p0
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -1,6 +1,8 @@
 class MainController < ApplicationController
   def index
-    if User.all.count > 0 && UserGroup.all.count > 0
+    user_count ||= User.all.size
+    user_group_count ||= UserGroup.all.size
+    unless user_count == 0 && user_group_count == 0
       render :index
     else
       render :first
@@ -29,10 +31,10 @@ class MainController < ApplicationController
 
   def stats
     counts = {
-        instruments: Instrument.all.count,
-        questions: CcQuestion.all.count,
-        variables: Variable.all.count,
-        users: User.all.count
+        instruments: Instrument.all.size,
+        questions: CcQuestion.all.size,
+        variables: Variable.all.size,
+        users: User.all.size
     }
     render json: counts
   end

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -10,7 +10,7 @@
 			"icon-bar"></span></button> <a class="navbar-brand" href="/instruments">{{softwareName}}</a>
 		</div>
 		<div class="navbar-collapse collapse" id="navbar">
-			<ul class="nav navbar-nav" data-ng-show="user.logged_in">
+			<ul class="nav navbar-nav" data-ng-if="user.logged_in">
 				<li data-ng-class="{active: isActive('/instruments')}">
 					<a href="/instruments">Instruments</a>
 				</li>
@@ -73,7 +73,7 @@
           </ul>
 				</li>
 				<li>
-					<a href="#" data-ng-show="user.logged_in" data-ng-click="sign_out()">Logout</a>
+					<a href="#" data-ng-if="user.logged_in" data-ng-click="sign_out()">Logout</a>
 				</li>
 			</ul>
 		</div><!--/.nav-collapse -->
@@ -82,7 +82,7 @@
 
 <div data-ng-if="!user.logged_in" data-ng-include="'sign_up_in.html'" data-ng-class="row"></div>
 
-<div data-ng-show="user.logged_in" class="container-fluid">
+<div data-ng-if="user.logged_in" class="container-fluid">
   <div class="view-container">
     <div data-ng-view class="view-frame animate-view"></div>
   </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,14 +48,4 @@ Rails.application.configure do
       metastore: (ENV["REDIS_URL"] || 'redis://127.0.0.1:6379') + '/1/metastore',
       entitystore: (ENV["REDIS_URL"] || 'redis://127.0.0.1:6379') + '/1/entitystore'
   }
-
-  # Bullet gem configuration
-  config.after_initialize do
-    Bullet.enable = true
-    Bullet.alert = true
-    Bullet.bullet_logger = true
-    Bullet.console = true
-    Bullet.rails_logger = true
-    Bullet.raise = true
-  end
 end


### PR DESCRIPTION
A few small changes to improve Archivist's pages loading times.
* Upgrade puma version to 3.11.3 (from Mar18) (it used to be 2.16.3 (from Jan16)). 
Note: I preferred not to upgrade to the latest version of Puma (3.12.0 / Jul18). I picked one of the more stable releases. 
* Replace the .count Ruby methods with .size methods to collect the size of arrays. '.size' is a more efficient method for what we need in those specific cases.
* Replaced Angular 'data-ng-show' with 'data-ng-if' in some cases. 'ng-show' will run and cache the queries even if they are not going to be displayed. 'ng-if' only run if the data is to be displayed. 

