### PR TITLE
Updating gem "loofah" as per GitHub security alert warning (CVE-2018-…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)


### PR DESCRIPTION
…16468).

Updating gem "loofah" to version 2.2.3 to fix a medium security level warning issued by Github. (https://github.com/flavorjones/loofah/issues/154)

