### PR TITLE
Sorting a gem security warning raised by Github.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     puma (3.11.3)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-cache (1.8.0)
       rack (>= 0.4)
     rack-protection (2.0.4)


### PR DESCRIPTION
Github raised a medium level alert regarding a vulnerability associated to the 'Rack' gem in Rails. 
See https://nvd.nist.gov/vuln/detail/CVE-2018-16471 for more details. 