### PR TITLE
Fix Problem with constructs disappearing because of parent null

### DIFF
--- a/app/controllers/construct_controller.rb
+++ b/app/controllers/construct_controller.rb
@@ -18,13 +18,14 @@ class ConstructController < BasicInstrumentController
     obj_name = self.class.model_class.name.underscore.to_sym
     params = wrap_parent_param(self.params, obj_name)
     params[obj_name] = shim_construct_type(params[obj_name])
-    # Do not add permition to :parent_type as it causes the parent_id to go missing
     params.require( obj_name )
-        .permit( [:label, :parent_id, :position, :branch, :instrument_id]  + self.class.params_list )
+        .permit( [:label, :parent_id, :parent_type, :position, :branch, :instrument_id]  + self.class.params_list )
   end
 
   private
   def shim_construct_type(p)
+    # Ensure that if the parent_type is a valid ParentalContstruct class name
+    # or that it can be matched to one.
     parental_classes = %w(CcCondition CcLoop CcQuestion CcSequence CcStatement)
     unless p[:parent_type].nil? || parental_classes.include?(p[:parent_type])
       p[:parent_type] = case p[:parent_type].downcase

--- a/app/controllers/construct_controller.rb
+++ b/app/controllers/construct_controller.rb
@@ -25,7 +25,8 @@ class ConstructController < BasicInstrumentController
 
   private
   def shim_construct_type(p)
-    unless p[:parent_type].nil?
+    parental_classes = %w(CcCondition CcLoop CcQuestion CcSequence CcStatement)
+    unless p[:parent_type].nil? || parental_classes.include?(p[:parent_type])
       p[:parent_type] = case p[:parent_type].downcase
                           when 'condition' then
                             'CcCondition'
@@ -43,10 +44,10 @@ class ConstructController < BasicInstrumentController
   end
 
   def wrap_parent_param(p, obj_name)
-    if p.has_key? :parent
-      p[obj_name][:parent_id] = p[:parent][:id]
-      p[obj_name][:parent_type] = p[:parent][:type]
-      p.delete(:parent)
+    parent_object = (p.has_key?(obj_name)) ? p[obj_name].delete(:parent) : p.delete(:parent)
+    if parent_object
+      p[obj_name][:parent_id] = parent_object[:id]
+      p[obj_name][:parent_type] = parent_object[:type]
     end
     p
   end

--- a/test/controllers/cc_conditions_controller_test.rb
+++ b/test/controllers/cc_conditions_controller_test.rb
@@ -39,8 +39,23 @@ class CcConditionsControllerTest < ActionController::TestCase
   end
 
   test "should update cc_condition" do
-    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @cc_condition, cc_condition: {literal: @cc_condition.literal, logic: @cc_condition.logic} }
+    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @cc_condition, cc_condition: {literal: @cc_condition.literal, logic: @cc_condition.logic, parent: {
+            id: @instrument.cc_sequences.first.id,
+            type: 'sequence'
+          }} }
     assert_response :success
+
+    assert_equal @cc_condition.reload.parent, @instrument.cc_sequences.first
+  end
+
+  test "should update cc_condition when parent type matches class name" do
+    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @cc_condition, cc_condition: {literal: @cc_condition.literal, logic: @cc_condition.logic, parent: {
+            id: @instrument.cc_sequences.first.id,
+            type: 'CcSequence'
+          }} }
+    assert_response :success
+
+    assert_equal @cc_condition.reload.parent, @instrument.cc_sequences.first
   end
 
   test "should destroy cc_condition" do

--- a/test/controllers/cc_loops_controller_test.rb
+++ b/test/controllers/cc_loops_controller_test.rb
@@ -42,8 +42,23 @@ class CcLoopsControllerTest < ActionController::TestCase
   end
 
   test "should update cc_loop" do
-    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @cc_loop, cc_loop: {end_val: @cc_loop.end_val, loop_var: @cc_loop.loop_var, loop_while: @cc_loop.loop_while, start_val: @cc_loop.start_val} }
+    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @cc_loop, cc_loop: {end_val: @cc_loop.end_val, loop_var: @cc_loop.loop_var, loop_while: @cc_loop.loop_while, start_val: @cc_loop.start_val, parent: {
+            id: @instrument.cc_sequences.first.id,
+            type: 'sequence'
+          }} }
     assert_response :success
+
+    assert_equal @cc_loop.reload.parent, @instrument.cc_sequences.first
+  end
+
+  test "should update cc_loop when parent type matches class name" do
+    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @cc_loop, cc_loop: {end_val: @cc_loop.end_val, loop_var: @cc_loop.loop_var, loop_while: @cc_loop.loop_while, start_val: @cc_loop.start_val, parent: {
+            id: @instrument.cc_sequences.first.id,
+            type: 'CcSequence'
+          }} }
+    assert_response :success
+
+    assert_equal @cc_loop.reload.parent, @instrument.cc_sequences.first
   end
 
   test "should destroy cc_loop" do

--- a/test/controllers/cc_questions_controller_test.rb
+++ b/test/controllers/cc_questions_controller_test.rb
@@ -41,8 +41,23 @@ class CcQuestionsControllerTest < ActionController::TestCase
   end
 
   test "should update cc_question" do
-    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @cc_question, cc_question: {question_id: @cc_question.question_id, question_type: @cc_question.question_type} }
+    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @cc_question, cc_question: {question_id: @cc_question.question_id, question_type: @cc_question.question_type, parent: {
+            id: @instrument.cc_sequences.first.id,
+            type: 'sequence'
+          }} }
     assert_response :success
+
+    assert_equal @cc_question.reload.parent, @instrument.cc_sequences.first
+  end
+
+  test "should update cc_question when parent type matches class name" do
+    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @cc_question, cc_question: {question_id: @cc_question.question_id, question_type: @cc_question.question_type, parent: {
+            id: @instrument.cc_sequences.first.id,
+            type: 'CcSequence'
+          }} }
+    assert_response :success
+
+    assert_equal @cc_question.reload.parent, @instrument.cc_sequences.first
   end
 
   test "should destroy cc_question" do

--- a/test/controllers/cc_sequences_controller_test.rb
+++ b/test/controllers/cc_sequences_controller_test.rb
@@ -50,12 +50,28 @@ class CcSequencesControllerTest < ActionController::TestCase
       instrument_id: @instrument.id,
       id: @cc_sequence.id,
       cc_sequence: {
-        label: "Updated label"
+        label: "Updated label",
+        parent: {
+            id: @instrument.cc_sequences.first.id,
+            type: 'sequence'
+        }
       }
     }
     # puts '----- AFTER -----'
     # puts CcSequence.find(146).label
     assert_response :success
+
+    assert_equal @cc_sequence.reload.parent, @instrument.cc_sequences.first
+  end
+
+  test "should update cc_sequence when parent type matches class name" do
+    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @cc_sequence, cc_sequence: {literal: @cc_sequence.literal, parent: {
+            id: @instrument.cc_sequences.first.id,
+            type: 'CcSequence'
+          }} }
+    assert_response :success
+
+    assert_equal @cc_sequence.reload.parent, @instrument.cc_sequences.first
   end
 
   test "should destroy cc_sequence" do

--- a/test/controllers/cc_statements_controller_test.rb
+++ b/test/controllers/cc_statements_controller_test.rb
@@ -40,8 +40,23 @@ class CcStatementsControllerTest < ActionController::TestCase
   end
 
   test "should update cc_statement" do
-    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @cc_statement, cc_statement: {literal: @cc_statement.literal} }
+    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @cc_statement, cc_statement: {literal: @cc_statement.literal, parent: {
+            id: @instrument.cc_sequences.first.id,
+            type: 'sequence'
+          }} }
     assert_response :success
+
+    assert_equal @cc_statement.reload.parent, @instrument.cc_sequences.first
+  end
+
+  test "should update cc_statement when parent type matches class name" do
+    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @cc_statement, cc_statement: {literal: @cc_statement.literal, parent: {
+            id: @instrument.cc_sequences.first.id,
+            type: 'CcSequence'
+          }} }
+    assert_response :success
+
+    assert_equal @cc_statement.reload.parent, @instrument.cc_sequences.first
   end
 
   test "should destroy cc_statement" do


### PR DESCRIPTION
Addresses #221 

When editing a construct the form can provide `parent_type` as either a lowercase string e.g. `sequence` or `CcSequence` depending on whether there has been a `fake move` or not. To allow for this we can accept either the ParentalConstruct subclass name or the lowercase name e.g. `sequence`. This means that the parent is now no longer null.