### PR TITLE
WIP: Category name appearing in code list form and using accept_nested_att…

### DIFF
--- a/app/assets/javascripts/sections/instruments/modules/build/controllers/code_lists.coffee
+++ b/app/assets/javascripts/sections/instruments/modules/build/controllers/code_lists.coffee
@@ -20,6 +20,8 @@ angular.module('archivist.build').controller(
           cl.count = cl.used_by.length
           cl
         $scope.sidebar_objs = (get_count_from_used_by obj for obj in $scope.instrument.CodeLists).sort_by_property()
+        DataManager.Data.Codes.Categories.$promise.then ->
+          $scope.categories = DataManager.Data.Codes.Categories
         $timeout ->
           offset = localStorage.getItem 'sidebar_scroll'
           if offset != null
@@ -73,7 +75,7 @@ angular.module('archivist.build').controller(
           DataManager.Data.ResponseDomains.Codes.$promise.then ->
             DataManager.groupResponseDomains()
         ,->
-          console.log("error")
+          Flash.add('danger', 'Code list failed to update!')
         )
 
         DataManager.Data.ResponseDomains[$routeParams.id] = null

--- a/app/assets/javascripts/templates/partials/build/code_lists.html
+++ b/app/assets/javascripts/templates/partials/build/code_lists.html
@@ -117,7 +117,7 @@
                 </button>
             </td>
         </tr>
-        <tr>
+        <tr data-ng-if="editMode">
             <td></td>
             <td>
                 <input

--- a/app/controllers/code_lists_controller.rb
+++ b/app/controllers/code_lists_controller.rb
@@ -6,7 +6,11 @@ class CodeListsController < BasicInstrumentController
   @model_class = CodeList
 
   # List of params that can be set and edited
-  @params_list = [:label, :codes, :min_responses, :max_responses]
+  @params_list = [:label, :min_responses, :max_responses, codes_attributes: [ :id, :value, category_attributes: [:id, :label] ]]
+
+  rescue_from ActiveRecord::RecordInvalid do |e|
+    render json: e.record.errors.full_messages, status: :unprocessable_entity
+  end
 
   # POST /instruments/1/code_lists.json
   def create
@@ -31,10 +35,6 @@ class CodeListsController < BasicInstrumentController
   def update
     parameters = safe_params
 
-    if params.has_key? :codes
-      @object.update_codes(params[:codes])
-      parameters.delete :codes
-    end
     if params.has_key? :rd
       if params[:rd]
         @object.response_domain = true
@@ -45,13 +45,36 @@ class CodeListsController < BasicInstrumentController
         @object.response_domain = false
       end
     end
-    respond_to do |format|
-      if @object.update(parameters)
+    if @object.update_attributes(parameters)
+      respond_to do |format|
         format.json { render :show, status: :ok }
-      else
+      end
+    else
+      respond_to do |format|
         format.json { render json: @object.errors, status: :unprocessable_entity }
       end
     end
+  end
+
+  private
+
+  def safe_params
+    # The params from Angular use :codes in the params array, we
+    # tranform these into params that comply with the params expected
+    # by nested attributes using accepts_nested_attributes for the codes
+    # and their nested categories.
+    codes_params = params[:code_list].delete(:codes)
+    if codes_params
+      codes_params.map do | code |
+        code[:category_attributes] = {
+          id: code.delete(:category_id),
+          label: code.delete(:label)
+        }
+        code
+      end
+      params[:code_list][:codes_attributes] = codes_params
+    end
+    super
   end
 
 end

--- a/app/models/code.rb
+++ b/app/models/code.rb
@@ -34,39 +34,18 @@ class Code < ApplicationRecord
   # Before creating a Code in the database ensure the instrument has been set
   before_create :set_instrument
 
+  # Accept nested attributes for category so that we can manage the
+  # Category from within a code form.
+  accepts_nested_attributes_for :category
+
   # All Codes require a CodeList and Category
   validates :category, :code_list, presence: true
 
   # Delegates label to Category, protecting against nil Category
-  #
-  # @return [String|Nil]
-  def label
-    self.category.nil? ? nil : self.category.label
-  end
-
-  # Allows the assigning of a new Category label in a protected way
-  #
-  # @param [String] val New Category label
-  def label=(val)
-    set_label(val, code_list.instrument)
-  end
+  delegate :label, to: :category, allow_nil: true
 
   # Sets instrument_id from the Code List that this Code belongs to
   def set_instrument
     self.instrument_id = self.code_list.instrument_id
-  end
-
-  # Sets a Category
-  #
-  # If the Category label already exists for this instrument then that Category
-  # is found and assigned, otherwise a new Category is created, saved and assigned.
-  #
-  # @param [String] val New Category label
-  # @param [Instrument] instrument Instrument to which Category belongs
-  def set_label(val, instrument)
-    self.category = Category.find_by label: val, instrument_id: instrument.id
-    if self.category.nil?
-      self.category = Category.create label: val, instrument: instrument
-    end
   end
 end

--- a/app/models/control_construct.rb
+++ b/app/models/control_construct.rb
@@ -55,15 +55,14 @@ class ControlConstruct < ApplicationRecord
           # puts "Id: #{self.id}"
           # puts "Parent_id: #{self.parent_id}"
           # puts "Parent_type: #{self.parent_type}"
-          $redis.hdel 'construct_children:' + self.parent_type, self.parent_id
+          $redis.hdel "construct_children:#{self.parent_type}", self.parent_id
         end
       end
       $redis.hdel 'parents', self.id
       $redis.hdel 'is_top', self.id
-    rescue => err
-      Rails.logger.warn "Cannot connect to Redis [Control Construct] -> Error: '#{err}'"
-      exit 1
-    end
+   rescue => err
+     Rails.logger.warn "Cannot connect to Redis [Control Construct] -> Error: '#{err}'"
+   end
   end
 
   private # Private methods

--- a/app/views/code_lists/index.json.jbuilder
+++ b/app/views/code_lists/index.json.jbuilder
@@ -6,6 +6,7 @@ json.array!(@collection) do |code_list|
     json.category_id code.category.id
     json.value code.value
     json.order code.order
+    json.label code.category.label
   end
   json.rd !code_list.response_domain.nil?
   unless code_list.response_domain.nil?

--- a/test/controllers/code_lists_controller_test.rb
+++ b/test/controllers/code_lists_controller_test.rb
@@ -32,6 +32,11 @@ class CodeListsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should give errors if trying to update code_list with invalid params" do
+    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @code_list, code_list: {label: @code_list.label, codes: [{ id: @code_list.codes.first.id, category_id: 5263, value: "1", label: '', order: 1}] }}
+    assert_response :unprocessable_entity
+  end
+
   test "should destroy code_list" do
     assert_difference('CodeList.count', -1) do
       delete :destroy, format: :json, params: { instrument_id: @instrument.id, id: @code_list }

--- a/test/models/code_test.rb
+++ b/test/models/code_test.rb
@@ -1,27 +1,11 @@
 require 'test_helper'
 
 class CodeJobTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-
   setup do
     @code = codes :Code_1
   end
 
   test "can read label" do
     assert_not_nil @code.label
-  end
-
-  test "can write to label with new category" do
-    assert_difference 'Category.count', 1 do
-      @code.label = 'totally new category'
-    end
-  end
-
-  test "can write to label with existing category" do
-    assert_difference 'Category.count', 0 do
-      @code.label = 'Yes'
-    end
   end
 end


### PR DESCRIPTION
…ributes for code_lists #160 #180

Addresses #160 and #180 

If a category label was blank then it was causing the `CodeList` to not save. This was the cause of both #160 and #180.

The category label inputs were blank when first loading the `CodeList` page as the `categories.json` was being loaded after the `CodeList` form was being displayed. We've addressed this by having the `label` attribute part of the `CodeList` JSON so we now longer get a blank category name.

I've also made it so that if a category name is blank i.e. you make the category name blank in the form for an existing code. Then the save of the `CodeList` will fail and the UI will say `Code list failed to update!`.

As an aside I've refactored the way we were handle updating codes and categories on a code list to use `accepts_nested_attributes_for` so that we have less code and replace it with reliable Rails behaviour.