### PR TITLE
Fix removing and then ordering codes in code lists #77

### DIFF
--- a/app/assets/javascripts/sections/instruments/modules/build/controllers/code_lists.coffee
+++ b/app/assets/javascripts/sections/instruments/modules/build/controllers/code_lists.coffee
@@ -134,6 +134,8 @@ angular.module('archivist.build').controller(
           if newVal != oldVal
             if newVal?
               scope.current.codes.push {id: null, value: newVal, category: null}
+              for i of $scope.current.codes
+                $scope.current.codes[i].order = i
               $scope.current.newValue = null
               #TODO: Remove DOM code from controllers
               $timeout(

--- a/app/models/code_list.rb
+++ b/app/models/code_list.rb
@@ -51,7 +51,7 @@ class CodeList < ApplicationRecord
 
   # Accept nested attributes for Codes so that we can manage associated
   # Codes from within a CodeList form.
-  accepts_nested_attributes_for :codes
+  accepts_nested_attributes_for :codes, allow_destroy: true
 
   # Returns all the {QuestionGrid QuestionGrids} that this CodeList has been
   # used as an axis in


### PR DESCRIPTION
Addresses #77 

* Added tests to assure that the order is being persisted for codes in code_list.
* Codes are removed correctly
* Order is now being used correctly in the UI so when you add a new code it doesn't go straight to the top.