### PR TITLE
Feature/298 response domain numeric integers

### DIFF
--- a/app/assets/javascripts/sections/instruments/modules/build/controllers/code_lists.coffee
+++ b/app/assets/javascripts/sections/instruments/modules/build/controllers/code_lists.coffee
@@ -134,6 +134,8 @@ angular.module('archivist.build').controller(
           if newVal != oldVal
             if newVal?
               scope.current.codes.push {id: null, value: newVal, category: null}
+              for i of $scope.current.codes
+                $scope.current.codes[i].order = i
               $scope.current.newValue = null
               #TODO: Remove DOM code from controllers
               $timeout(

--- a/app/models/code_list.rb
+++ b/app/models/code_list.rb
@@ -51,7 +51,7 @@ class CodeList < ApplicationRecord
 
   # Accept nested attributes for Codes so that we can manage associated
   # Codes from within a CodeList form.
-  accepts_nested_attributes_for :codes
+  accepts_nested_attributes_for :codes, allow_destroy: true
 
   # Returns all the {QuestionGrid QuestionGrids} that this CodeList has been
   # used as an axis in

--- a/app/views/response_domain_numerics/index.json.jbuilder
+++ b/app/views/response_domain_numerics/index.json.jbuilder
@@ -1,5 +1,7 @@
 json.array!(@collection) do |response_domain_numeric|
-  json.extract! response_domain_numeric, :id, :label, :min, :max
+  json.extract! response_domain_numeric, :id, :label
+  json.min (response_domain_numeric.numeric_type == 'Integer') ? response_domain_numeric.min.to_i : response_domain_numeric.min.to_f
+  json.max (response_domain_numeric.numeric_type == 'Integer') ? response_domain_numeric.max.to_i : response_domain_numeric.max.to_f
   json.subtype response_domain_numeric.numeric_type
   json.type 'ResponseDomainNumeric'
 end


### PR DESCRIPTION
Addresses #298 

This issue was caused by the fact that the html input type `number` is used but the JSON was providing a string as that's what the DB field is. Instead we give either a integer or a float based on the numeric type.