### PR TITLE
Allow blank string to be used as min/max

### DIFF
--- a/app/models/response_domain_numeric.rb
+++ b/app/models/response_domain_numeric.rb
@@ -24,4 +24,20 @@ class ResponseDomainNumeric < ApplicationRecord
   def params
     '(' + (self.min.nil? ? '~' : '%g' % self.min) + ',' + (self.max.nil? ? '~' : '%g' % self.max) + ')'
   end
+
+  # Return min in the correct class if it's nil, integer or float
+  #
+  # @return [Nil, Integer, Float] Min value
+  def min
+    return super if super.nil?
+    (numeric_type == 'Integer') ? super.to_i : super.to_f
+  end
+
+  # Return max in the correct class if it's nil, integer or float
+  #
+  # @return [Nil, Integer, Float] Max value
+  def max
+    return super if super.nil?
+    (numeric_type == 'Integer') ? super.to_i : super.to_f
+  end
 end

--- a/app/views/response_domain_numerics/index.json.jbuilder
+++ b/app/views/response_domain_numerics/index.json.jbuilder
@@ -1,7 +1,5 @@
 json.array!(@collection) do |response_domain_numeric|
-  json.extract! response_domain_numeric, :id, :label
-  json.min (response_domain_numeric.numeric_type == 'Integer') ? response_domain_numeric.min.to_i : response_domain_numeric.min.to_f
-  json.max (response_domain_numeric.numeric_type == 'Integer') ? response_domain_numeric.max.to_i : response_domain_numeric.max.to_f
+  json.extract! response_domain_numeric, :id, :label, :min, :max
   json.subtype response_domain_numeric.numeric_type
   json.type 'ResponseDomainNumeric'
 end

--- a/test/controllers/response_domain_numerics_controller_test.rb
+++ b/test/controllers/response_domain_numerics_controller_test.rb
@@ -32,6 +32,14 @@ class ResponseDomainNumericsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should update response_domain_numeric min with nil if left blank" do
+    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @response_domain_numeric, response_domain_numeric: {label: @response_domain_numeric.label, max: '', min: '', numeric_type: @response_domain_numeric.numeric_type} }
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_nil json['min']
+    assert_nil json['max']
+  end
+
   test "should destroy response_domain_numeric" do
     assert_difference('ResponseDomainNumeric.count', -1) do
       delete :destroy, format: :json, params: { instrument_id: @instrument.id, id: @response_domain_numeric }


### PR DESCRIPTION
Addresses #298 

If a user enters a blank value in the min/max then it's stored as null in the database and not returned as 0.0 or 0.