### PR TITLE
Persist min_responses and max_responses on code list creation #180

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
 services:
   - postgresql
   - redis-server
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 #before_install:
 #  - rm -f Gemfile.lock
 before_script:

--- a/app/controllers/code_lists_controller.rb
+++ b/app/controllers/code_lists_controller.rb
@@ -6,7 +6,7 @@ class CodeListsController < BasicInstrumentController
   @model_class = CodeList
 
   # List of params that can be set and edited
-  @params_list = [:label, :min_responses, :max_responses, codes_attributes: [ :id, :value, :order, :_destroy, :category_id, category_attributes: [:id, :instrument_id, :label] ]]
+  @params_list = [:label, codes_attributes: [ :id, :value, :order, :_destroy, :category_id, category_attributes: [:id, :instrument_id, :label] ]]
 
   # POST /instruments/1/code_lists.json
   def create
@@ -15,6 +15,9 @@ class CodeListsController < BasicInstrumentController
     if @object.save
       if params.has_key?(:rd) && params[:rd]
         @object.response_domain = true
+        @object.response_domain.min_responses = params[:min_responses]
+        @object.response_domain.max_responses = params[:max_responses]
+        @object.response_domain.save!
       else
         @object.response_domain = false
       end

--- a/test/controllers/code_lists_controller_test.rb
+++ b/test/controllers/code_lists_controller_test.rb
@@ -22,6 +22,14 @@ class CodeListsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should create with the min_responses and max_responses" do
+    post :create, format: :json, params: { instrument_id: @instrument.id, rd: true, min_responses: 2, max_responses: 3, code_list: { label: @code_list.label + '_i', instrument_id: @instrument.id} }
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal json['min_responses'], 2
+    assert_equal json['max_responses'], 3
+  end
+
   test "should show code_list" do
     get :show, format: :json, params: { instrument_id: @instrument.id, id: @code_list }
     assert_response :success
@@ -42,6 +50,14 @@ class CodeListsControllerTest < ActionController::TestCase
     patch :update, format: :json, params: { instrument_id: @instrument.id, id: @code_list, code_list: {label: @code_list.label, codes: [{ id: @code_list.codes.first.id, category_id: 5263, value: "1", label: 'New Label', order: 1}] }}
     assert_response :success
     refute_includes @code_list.reload.codes, code_to_be_deleted
+  end
+
+  test "should update with the min_responses and max_responses" do
+    patch :update, format: :json, params: { instrument_id: @instrument.id, id: @code_list, rd: true, min_responses: 3, max_responses: 4, code_list: {label: @code_list.label} }
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal json['min_responses'], 3
+    assert_equal json['max_responses'], 4
   end
 
   test "should persist order from the code parameters" do


### PR DESCRIPTION
Addresses #180 

`min_responses` and `max_responses` are now persisted on create and update for code lists.