### PR TITLE
Nokogiri fix as per Github security issue warning.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,7 @@ GEM
     mustermann (1.0.3)
     newrelic_rpm (5.7.0.350)
     nio4r (2.3.1)
-    nokogiri (1.10.2)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     oj (3.3.9)
     orm_adapter (0.5.0)


### PR DESCRIPTION
Updating Nokogiri gem to solve a security issue raised by Github. 
For more details, see https://nvd.nist.gov/vuln/detail/CVE-2019-5477 