### PR TITLE
Add find_nearest_parent(target_class) to ControlConstruct #227

### DIFF
--- a/app/models/control_construct.rb
+++ b/app/models/control_construct.rb
@@ -34,6 +34,40 @@ class ControlConstruct < ApplicationRecord
   # After destroying, clear the cache from Redis
   after_destroy :clear_cache
 
+  # Recursive search through the parent tree and finds and returns the nearest
+  # parent of the target_class
+  def find_nearest_parent(target_class)
+    columns = ['id', 'parent_id', 'construct_id', 'construct_type']
+    columns_joined = columns.join(',')
+    sql =
+      <<-SQL
+        WITH RECURSIVE control_constructs_tree (#{columns_joined}, level)
+        AS (
+          SELECT
+            #{columns_joined},
+            0
+          FROM control_constructs
+          WHERE construct_id = #{id}
+          AND construct_type = '#{self.class.name}'
+
+          UNION ALL
+          SELECT
+            #{columns.map { |col| 'cat.' + col }.join(',')},
+            ct.level + 1
+          FROM control_constructs cat, control_constructs_tree ct
+          WHERE cat.id = ct.parent_id
+        )
+        SELECT #{target_class.table_name}.*
+        FROM control_constructs_tree
+        INNER JOIN #{target_class.table_name} ON #{target_class.table_name}.id = control_constructs_tree.construct_id
+        WHERE level > 0
+        AND construct_type = '#{target_class.name}'
+        ORDER BY level, control_constructs_tree.id, construct_id, construct_type
+        LIMIT 1;
+      SQL
+    target_class.find_by_sql(sql.chomp).first
+  end
+
   # Clears the Redis cache of construct positional information
   def clear_cache
     begin

--- a/app/views/instruments/mapper.txt.erb
+++ b/app/views/instruments/mapper.txt.erb
@@ -1,11 +1,11 @@
 <% @object.cc_sequences.order(id: 'ASC').each do |sequence| %>
-  <%=raw sequence.urn %>|Sequence|-|<%=raw (p = sequence.parent(CcSequence)).nil? ? '-' : p.urn %>| <%=raw (s = sequence.label).nil? ? s = 'Empty label' : s = (raw sequence.label.gsub("\n","").gsub("\r","")) %>
+  <%=raw sequence.urn %>|Sequence|-|<%=raw (p = sequence.find_nearest_parent(CcSequence)).nil? ? '-' : p.urn %>| <%=raw (s = sequence.label).nil? ? s = 'Empty label' : s = (raw sequence.label.gsub("\n","").gsub("\r","")) %>
   <% end %>
   <%= puts %>
   <% @object.cc_questions.order(id: 'ASC').each do |qc| %>
     <% if qc.question_type == 'QuestionItem' %>
-    <%=raw qc.label %> |Question|-|<%=raw qc.parent(CcSequence).urn %>|-|<%=raw qc.question.literal.gsub("\n","").gsub("\r","") %>
+    <%=raw qc.label %> |Question|-|<%=raw qc.find_nearest_parent(CcSequence).try(:urn) %>|-|<%=raw qc.question.literal.gsub("\n","").gsub("\r","") %>
     <% else %>
-    <%=raw qc.label %> |Question|[<%=raw qc.question.max_y %>,<%=raw qc.question.max_x %>]|  <%=raw qc.parent(CcSequence).urn %> |<%=raw qc.question.literal.gsub("\n","").gsub("\r","") %>
+    <%=raw qc.label %> |Question|[<%=raw qc.question.max_y %>,<%=raw qc.question.max_x %>]|  <%=raw qc.find_nearest_parent(CcSequence).try(:urn) %> |<%=raw qc.question.literal.gsub("\n","").gsub("\r","") %>
     <% end %>
 <% end %>


### PR DESCRIPTION
Addresses #227 so that we can recursively find the nearest parent (in this case the CcSequence) of a control construct.