### PR TITLE
Handle an exception being raised on a import line elegantly

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
         topic_v:
           record_invalid_dataset: "Record Invalid as dataset name in file (%{dataset_from_line}) does not match the Dataset assigned to this import (%{dataset_from_object})."
           wrong_number_of_columns: "Record Invalid you must have 3 columns (Dataset identifier, Variable name and Topic code). You only provided %{actual_number_of_columns}"
-        topic_v:
+        topic_q:
           record_invalid_control_construct_scheme: "Record Invalid as Control Construct Scheme name in file (%{control_construct_scheme_from_line}) does not match the Control Construct Scheme assigned to this import (%{control_construct_scheme_from_object})."
           wrong_number_of_columns: "Record Invalid you must have 3 columns (Control Construct Scheme, Question Construct, Dataset identifier and Variable name). You only provided %{actual_number_of_columns}"
         mapping:

--- a/lib/importers/txt/mapper/dv.rb
+++ b/lib/importers/txt/mapper/dv.rb
@@ -5,31 +5,31 @@ class Importers::TXT::Mapper::DV < Importers::TXT::Mapper::Dataset
     begin
         @doc.each do |variable_dataset, v, source_dataset, s|
           log :input, "#{variable_dataset},#{v},#{source_dataset},#{s}"
-          if variable_dataset.blank? || source_dataset.blank? || v.blank? || s.blank?
-            @errors = true
-            log :outcome, I18n.t('importers.txt.mapper.dv.wrong_number_of_columns', actual_number_of_columns: {a: source_dataset, b: variable_dataset, c: v, d: s}.compact.count)
-            write_to_log
-            next
-          elsif variable_dataset != @object.instance_name
-            @errors = true
-            log :outcome, I18n.t('importers.txt.mapper.dv.record_invalid_dataset', dataset_from_line: variable_dataset, dataset_from_object: @object.instance_name)
-            write_to_log
-            next
-          end
-          var = vars.find_by_name v
-          src = vars.find_by_name s
-          log :matches, "matched to Variable (#{var}) AND Source (#{src})"
-          unless var.nil? or src.nil?
-            var.var_type = 'Derived'
-            var.src_variables << src
-            if var.save
-              log :outcome, "Record Saved"
-            else
-              errors = true
-              log :outcome, "Record Invalid : #{var.errors.full_messages.to_sentence}"
+          begin
+            if variable_dataset.blank? || source_dataset.blank? || v.blank? || s.blank?
+              raise StandardError.new(I18n.t('importers.txt.mapper.dv.wrong_number_of_columns', actual_number_of_columns: {a: source_dataset, b: variable_dataset, c: v, d: s}.compact.count))
+            elsif variable_dataset != @object.instance_name
+              raise StandardError.new(I18n.t('importers.txt.mapper.dv.record_invalid_dataset', dataset_from_line: variable_dataset, dataset_from_object: @object.instance_name))
             end
+            var = vars.find_by_name v
+            src = vars.find_by_name s
+            log :matches, "matched to Variable (#{var}) AND Source (#{src})"
+            unless var.nil? or src.nil?
+              var.var_type = 'Derived'
+              var.src_variables << src
+              if var.save
+                log :outcome, "Record Saved"
+              else
+                errors = true
+                log :outcome, "Record Invalid : #{var.errors.full_messages.to_sentence}"
+              end
+            end
+          rescue StandardError => e
+            @errors = true
+            log :outcome, (e.message =~ /Record Invalid/) ? e.message : "Record Invalid : #{e.message}"
+          ensure
+            write_to_log
           end
-          write_to_log
         end
     rescue => exception
       Rails.logger.info exception.message

--- a/lib/importers/txt/mapper/mapping.rb
+++ b/lib/importers/txt/mapper/mapping.rb
@@ -9,50 +9,50 @@ class Importers::TXT::Mapper::Mapping < Importers::TXT::Mapper::Instrument
     set_import_to_running
     @doc.each do |control_construct_scheme, q, dataset, v|
       log :input, "#{control_construct_scheme},#{q},#{dataset},#{v}"
-
-      if control_construct_scheme.blank? || dataset.blank? || q.blank? || v.blank?
-        @errors = true
-        log :outcome, I18n.t('importers.txt.mapper.mapping.wrong_number_of_columns', actual_number_of_columns: {a: control_construct_scheme, b: q, c: v, d: dataset}.compact.count)
-        write_to_log
-        next
-      elsif control_construct_scheme != @object.control_construct_scheme
-        @errors = true
-        log :outcome, I18n.t('importers.txt.mapper.mapping.record_invalid_control_construct_scheme', control_construct_scheme_from_line: control_construct_scheme, control_construct_scheme_from_object: @object.control_construct_scheme)
-        write_to_log
-        next
-      end
-
-      q_ident, q_coords = *q.split('$')
-      qc = @object.cc_questions.find_by_label q_ident
-
-      multidimensional_variable_finder = lambda do |name|
-        @variables.each do |cp|
-          found = cp.find_by('lower(name) = ?', name.downcase)
-          return found unless found.nil?
+      begin
+        if control_construct_scheme.blank? || dataset.blank? || q.blank? || v.blank?
+          raise StandardError.new(I18n.t('importers.txt.mapper.mapping.wrong_number_of_columns', actual_number_of_columns: {a: control_construct_scheme, b: q, c: v, d: dataset}.compact.count))
+        elsif control_construct_scheme != @object.control_construct_scheme
+          raise StandardError.new(I18n.t('importers.txt.mapper.mapping.record_invalid_control_construct_scheme', control_construct_scheme_from_line: control_construct_scheme, control_construct_scheme_from_object: @object.control_construct_scheme))
         end
-        return nil
-      end
 
-      var = multidimensional_variable_finder.call(v)
-      log :matches, "matched to QuestionContruct(#{qc}) AND Variable (#{var})"
-      if qc.nil? || var.nil?
-        @errors = true
-        log :outcome, "Record Invalid as QuestionContruct and Variable where not found"
-      else
-        fields = { variable: var }
-        unless q_coords.nil?
-          x, y = *q_coords.split(';')
-          fields = fields.merge(x: x.to_i, y: y.to_i)
+        q_ident, q_coords = *q.split('$')
+        qc = @object.cc_questions.find_by_label q_ident
+
+        multidimensional_variable_finder = lambda do |name|
+          return unless name
+          @variables.each do |cp|
+            found = cp.find_by('lower(name) = ?', name.downcase)
+            return found unless found.nil?
+          end
+          return nil
         end
-        map = qc.maps.find_or_initialize_by variable: var, x: x.to_i, y: y.to_i
-        if map.save
-          log :outcome, "Record Saved"
-        else
+
+        var = multidimensional_variable_finder.call(v)
+        log :matches, "matched to QuestionContruct(#{qc}) AND Variable (#{var})"
+        if qc.nil? || var.nil?
           @errors = true
-          log :outcome, "Record Invalid : #{map.errors.full_messages.to_sentence}"
+          log :outcome, "Record Invalid as QuestionContruct and Variable where not found"
+        else
+          fields = { variable: var }
+          unless q_coords.nil?
+            x, y = *q_coords.split(';')
+            fields = fields.merge(x: x.to_i, y: y.to_i)
+          end
+          map = qc.maps.find_or_initialize_by variable: var, x: x.to_i, y: y.to_i
+          if map.save
+            log :outcome, "Record Saved"
+          else
+            @errors = true
+            log :outcome, "Record Invalid : #{map.errors.full_messages.to_sentence}"
+          end
         end
+      rescue StandardError => e
+        @errors = true
+        log :outcome, (e.message =~ /Record Invalid/) ? e.message : "Record Invalid : #{e.message}"
+      ensure
+        write_to_log
       end
-      write_to_log
     end
     set_import_to_finished
   end

--- a/lib/importers/txt/mapper/topic_q.rb
+++ b/lib/importers/txt/mapper/topic_q.rb
@@ -4,34 +4,34 @@ class Importers::TXT::Mapper::TopicQ < Importers::TXT::Mapper::Instrument
     set_import_to_running
     @doc.each do |control_construct_scheme, q, t|
       log :input, "#{control_construct_scheme},#{q},#{t}"
-      if control_construct_scheme.blank? || q.blank? || t.blank?
-        @errors = true
-        log :outcome, I18n.t('importers.txt.mapper.topic_q.wrong_number_of_columns', actual_number_of_columns: {a: control_construct_scheme, b: q, c: t}.compact.count)
-        write_to_log
-        next
-      elsif control_construct_scheme != @object.control_construct_scheme
-        @errors = true
-        log :outcome, I18n.t('importers.txt.mapper.topic_q.record_invalid_control_construct_scheme', control_construct_scheme_from_line: control_construct_scheme, control_construct_scheme_from_object: @object.control_construct_scheme)
-        write_to_log
-        next
-      end
-      qc = @object.cc_questions.find_by_label q
-      topic = Topic.find_by_code t
-      log :matches, "matched to QuestionContruct(#{qc}) AND Topic (#{topic})"
-      if qc.nil? || topic.nil?
-        @errors = true
-        log :outcome, "Record Invalid as QuestionContruct and Topic where not found"
-      else
-        qc.topic = topic
-        if qc.save
-          log :outcome, "Record Saved"
-          cc_question_ids_to_delete.delete(qc.id)
-        else
-          @errors = true
-          log :outcome, "Record Invalid : #{qc.errors.full_messages.to_sentence}"
+      begin
+        if control_construct_scheme.blank? || q.blank? || t.blank?
+          raise StandardError.new(I18n.t('importers.txt.mapper.topic_q.wrong_number_of_columns', actual_number_of_columns: {a: control_construct_scheme, b: q, c: t}.compact.count))
+        elsif control_construct_scheme != @object.control_construct_scheme
+          raise StandardError.new(I18n.t('importers.txt.mapper.topic_q.record_invalid_control_construct_scheme', control_construct_scheme_from_line: control_construct_scheme, control_construct_scheme_from_object: @object.control_construct_scheme))
         end
+        qc = @object.cc_questions.find_by_label q
+        topic = Topic.find_by_code t
+        log :matches, "matched to QuestionContruct(#{qc}) AND Topic (#{topic})"
+        if qc.nil? || topic.nil?
+          @errors = true
+          log :outcome, "Record Invalid as QuestionContruct and Topic where not found"
+        else
+          qc.topic = topic
+          if qc.save
+            log :outcome, "Record Saved"
+            cc_question_ids_to_delete.delete(qc.id)
+          else
+            @errors = true
+            log :outcome, "Record Invalid : #{qc.errors.full_messages.to_sentence}"
+          end
+        end
+      rescue StandardError => e
+        @errors = true
+        log :outcome, (e.message =~ /Record Invalid/) ? e.message : "Record Invalid : #{e.message}"
+      ensure
+        write_to_log
       end
-      write_to_log
     end
     Link.where(target_type: 'CcQuestion', target_id: cc_question_ids_to_delete).delete_all
     set_import_to_finished

--- a/lib/importers/txt/mapper/topic_v.rb
+++ b/lib/importers/txt/mapper/topic_v.rb
@@ -5,38 +5,38 @@ class Importers::TXT::Mapper::TopicV < Importers::TXT::Mapper::Dataset
     vars = @object.variables.includes(:questions, :src_variables, :der_variables, :topic)
     @doc.each do |dataset, v, t|
       log :input, "#{dataset},#{v},#{t}"
-      if dataset.blank? || v.blank? || t.blank?
-        @errors = true
-        log :outcome, I18n.t('importers.txt.mapper.topic_v.wrong_number_of_columns', actual_number_of_columns: {a: dataset, b: v, c: t}.compact.count)
-        write_to_log
-        next
-      elsif dataset != @object.instance_name
-        @errors = true
-        log :outcome, I18n.t('importers.txt.mapper.topic_v.record_invalid_dataset', dataset_from_line: dataset, dataset_from_object: @object.instance_name)
-        write_to_log
-        next
-      end
-      if @doc.config[0]&.include? :icase
-        var = vars.where('lower(name) = ?', v.downcase).first
-      else
-        var = vars.find_by_name v
-      end
-      topic = Topic.find_by_code t
-      log :matches, "matched to Variable (#{var}) AND Topic (#{topic})"
-      if var.nil? || topic.nil?
-        @errors = true
-        log :outcome, "Record Invalid as Variable and Topic where not found"
-      else
-        variable_ids_to_delete.delete(var.id)
-        var.topic = topic
-        if var.save
-          log :outcome, "Record Saved"
-        else
-          @errors = true
-          log :outcome, "Record Invalid : #{var.errors.full_messages.to_sentence}"
+      begin
+        if dataset.blank? || v.blank? || t.blank?
+          raise StandardError.new(I18n.t('importers.txt.mapper.topic_v.wrong_number_of_columns', actual_number_of_columns: {a: dataset, b: v, c: t}.compact.count))
+        elsif dataset != @object.instance_name
+          raise StandardError.new(I18n.t('importers.txt.mapper.topic_v.record_invalid_dataset', dataset_from_line: dataset, dataset_from_object: @object.instance_name))
         end
+        if @doc.config[0]&.include? :icase
+          var = vars.where('lower(name) = ?', v.downcase).first
+        else
+          var = vars.find_by_name v
+        end
+        topic = Topic.find_by_code t
+        log :matches, "matched to Variable (#{var}) AND Topic (#{topic})"
+        if var.nil? || topic.nil?
+          @errors = true
+          log :outcome, "Record Invalid as Variable and Topic where not found"
+        else
+          variable_ids_to_delete.delete(var.id)
+          var.topic = topic
+          if var.save
+            log :outcome, "Record Saved"
+          else
+            @errors = true
+            log :outcome, "Record Invalid : #{var.errors.full_messages.to_sentence}"
+          end
+        end
+      rescue StandardError => e
+        @errors = true
+        log :outcome, (e.message =~ /Record Invalid/) ? e.message : "Record Invalid : #{e.message}"
+      ensure
+        write_to_log
       end
-      write_to_log
     end
     # Remove all topic links if the variable is not used in the import
     Link.where(target_type: 'Variable', target_id: variable_ids_to_delete).delete_all


### PR DESCRIPTION
At the moment if an exception is raised while importing a TXT file it leaves the import in a `running` state. This change makes it so that the line that caused the error is caught in the logs as an `Record Invalid` line meaning that we can debug it.