### PR TITLE
Fix incorrect reference on question grid import #312

### DIFF
--- a/lib/importers/xml/ddi/question.rb
+++ b/lib/importers/xml/ddi/question.rb
@@ -23,7 +23,7 @@ module Importers::XML::DDI
       )
       roster = node.at_xpath("./GridDimension[@rank='1']/Roster")
       unless roster.nil?
-        question.roster_label = roster.at_xpath('./Label/r:Content').content
+        question.roster_label = roster.at_xpath('./Label/Content').content
         question.roster_rows = roster.attribute('minimumRequired').value.nil? ? 0 : roster.attribute('minimumRequired').value.to_i
       end
 

--- a/test/factories/question_grids.rb
+++ b/test/factories/question_grids.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :question_grid do
+    sequence(:label) { |n| "Label ##{n}" }
+    sequence(:literal) { |n| "Literal #{n}" }
+    question_type { 'QuestionGrid'}
+    instrument
+    horizontal_code_list factory: :code_list
+    vertical_code_list factory: :code_list
+  end
+end


### PR DESCRIPTION
Addresses #312 

Question grids with rosters were breaking the import which was stopping the constructs from importing.