### PR TITLE
Fix issue with StructuredMixedResponseDomain not being imported

### DIFF
--- a/lib/importers/xml/ddi/question.rb
+++ b/lib/importers/xml/ddi/question.rb
@@ -1,6 +1,7 @@
 module Importers::XML::DDI
   class Question < DdiImporterBase
     RESPONSE_DOMAIN_XPATH = './CodeDomain|./NumericDomain|./TextDomain|./DateTimeDomain'
+    STRUCTURED_RESPONSE_DOMAIN_XPATH = './StructuredMixedResponseDomain/ResponseDomainInMixed/CodeDomain|./StructuredMixedResponseDomain/ResponseDomainInMixed/NumericDomain|./StructuredMixedResponseDomain/ResponseDomainInMixed/TextDomain|./StructuredMixedResponseDomain/ResponseDomainInMixed/DateTimeDomain'
 
     def initialize(instrument)
       @instrument = instrument
@@ -73,7 +74,7 @@ module Importers::XML::DDI
       )
       @instrument.question_items << question
 
-      node.xpath(RESPONSE_DOMAIN_XPATH).each_with_index do |rd, i|
+      node.xpath(RESPONSE_DOMAIN_XPATH + '|' + STRUCTURED_RESPONSE_DOMAIN_XPATH).each_with_index do |rd, i|
         response_domain = read_response_domain(rd)
         next if response_domain.nil?
         ::RdsQs.create(

--- a/test/lib/importers/xml/ddi/question_test.rb
+++ b/test/lib/importers/xml/ddi/question_test.rb
@@ -44,6 +44,53 @@ class Importers::XML::DDI::QuestionTest < ActiveSupport::TestCase
       assert_equal(response_domain.min_responses, 1)
       assert_equal(response_domain.max_responses, 1)
     end
+
+    describe 'with ResponseDomainInMixed' do
+      it "should record response cardinality for code list" do
+        instrument = FactoryBot.create(:instrument, study: 'uk.alspac')
+        question_item = FactoryBot.create(:question_item, instrument: instrument)
+        code_list = FactoryBot.create(:code_list, instrument: instrument)
+        instruction = FactoryBot.create(:instruction, instrument: instrument)
+        code_list.add_urn(code_list.urn)
+        text = %Q|
+        <QuestionItem>
+          <URN>#{question_item.urn}</URN>
+          <UserAttributePair>
+            <AttributeKey>extension:Label</AttributeKey>
+            <AttributeValue>{"en-GB":"A1 a"}</AttributeValue>
+          </UserAttributePair>
+          <QuestionItemName>
+            <String xml:lang="en-GB">qi_A1_a</String>
+          </QuestionItemName>
+          <QuestionText audienceLanguage="en-GB">
+            <LiteralText>
+              <Text>The school gives high priority to raising pupils' standards of achievement</Text>
+            </LiteralText>
+          </QuestionText>
+          <StructuredMixedResponseDomain>
+            <ResponseDomainInMixed>
+              <CodeDomain>
+                <CodeListReference>
+                  <URN>#{code_list.urn}</URN>
+                  <TypeOfObject>CodeList</TypeOfObject>
+                </CodeListReference>
+                <ResponseCardinality minimumResponses="1" maximumResponses="1"></ResponseCardinality>
+              </CodeDomain>
+            </ResponseDomainInMixed>
+          </StructuredMixedResponseDomain>
+          <InterviewerInstructionReference>
+            <URN>#{instruction.urn}</URN>
+            <TypeOfObject>Instruction</TypeOfObject>
+          </InterviewerInstructionReference>
+        </QuestionItem>
+        |
+        node = Nokogiri(text).children
+        Importers::XML::DDI::Question.new(instrument).question_item_node(node)
+        response_domain = code_list.reload.response_domain
+        assert_equal(response_domain.min_responses, 1)
+        assert_equal(response_domain.max_responses, 1)
+      end
+    end
   end
 
   describe ".XML_node" do


### PR DESCRIPTION
Addresses #312 where the response domains are inside `StructuredMixedResponseDomain` which is not being imported.