### PR TITLE
Feature/code list multiple response domain codes 406 409

### DIFF
--- a/app/models/code_list.rb
+++ b/app/models/code_list.rb
@@ -36,15 +36,19 @@ class CodeList < ApplicationRecord
   # Every {QuestionGrid} where this CodeList was used as a horizontal axis
   #
   # Horizontal axis is considered to be rank 2 in DDI
-  has_many :qgrids_via_h, class_name: 'QuestionGrid', foreign_key: 'horizontal_code_list_id'
+  has_many :qgrids_via_h, class_name: 'QuestionGrid', foreign_key: 'horizontal_code_list_id', dependent: :destroy
 
   # Every {QuestionGrid} where this CodeList was used as a vertical axis
   #
   # Vertical axis is considered to be rank 1 in DDI
-  has_many :qgrids_via_v, class_name: 'QuestionGrid', foreign_key: 'vertical_code_list_id'
+  has_many :qgrids_via_v, class_name: 'QuestionGrid', foreign_key: 'vertical_code_list_id', dependent: :destroy
 
   # Each CodeList can optionally be represented as a {ResponseDomainCode}
   has_one :response_domain_code, dependent: :destroy
+
+  # Because of Foreign key constraints we need to ensure that all ResponseDomainCodes
+  # are removed even if they've been created in error.
+  has_many :response_domain_codes, dependent: :destroy
 
   # Accept nested attributes for Codes so that we can manage associated
   # Codes from within a CodeList form.

--- a/app/models/response_domain_code.rb
+++ b/app/models/response_domain_code.rb
@@ -13,7 +13,7 @@ class ResponseDomainCode < ApplicationRecord
   include ResponseDomain
 
   # All ResponseDomainCodes must belong to a {CodeList}
-  belongs_to :code_list, dependent: :destroy
+  belongs_to :code_list
 
   # ResponseDomainCodes can have many {Code}s through {CodeList}
   has_many :codes, through: :code_list

--- a/app/models/response_domain_code.rb
+++ b/app/models/response_domain_code.rb
@@ -13,7 +13,7 @@ class ResponseDomainCode < ApplicationRecord
   include ResponseDomain
 
   # All ResponseDomainCodes must belong to a {CodeList}
-  belongs_to :code_list
+  belongs_to :code_list, dependent: :destroy
 
   # ResponseDomainCodes can have many {Code}s through {CodeList}
   has_many :codes, through: :code_list

--- a/app/views/instruments/response_domain_codes.json.jbuilder
+++ b/app/views/instruments/response_domain_codes.json.jbuilder
@@ -1,4 +1,5 @@
-json.array! @object.response_domain_codes do |rd|
+json.array! @object.response_domain_codes.group_by(&:code_list_id) do | code_list_id, rds|
+  rd = rds.first
   json.id rd.id
   json.type rd.class.name
   json.label rd.label


### PR DESCRIPTION
Addresses #406 and #409

The core of both problems were foreign keys causing errors when deleting code lists and response domain code duplicates.