### PR TITLE
RdsQs should now be imported and exported with the correct value #312

### DIFF
--- a/app/models/question_grid.rb
+++ b/app/models/question_grid.rb
@@ -55,19 +55,26 @@ class QuestionGrid < ApplicationRecord
   #
   # @return [Array] All response domains
   def response_domains
+    grid_rds_qs.map { |x| x.response_domain }
+  end
+
+  # Returns all grid rds_qs using horizontal_code_list_id
+  #
+  # @return [Array] All RdsQs
+  def grid_rds_qs
     sql = <<~SQL
       SELECT rds_qs.*
       FROM rds_qs
       INNER JOIN question_grids
-      ON question_grids.id = rds_qs.question_id
+        ON question_grids.id = rds_qs.question_id
         AND rds_qs.question_type = 'QuestionGrid'
       INNER JOIN codes
-      ON codes.code_list_id = question_grids.horizontal_code_list_id
+        ON codes.code_list_id = question_grids.horizontal_code_list_id
+        AND codes.value::int = rds_qs.code_id
       WHERE question_grids.id = ?
       ORDER BY codes.order
     SQL
-    rds_qs = RdsQs.find_by_sql ([sql, self.id])
-    rds_qs.map { |x| x.response_domain }
+    RdsQs.find_by_sql ([sql, self.id])
   end
 
   # Exports as an XML fragment

--- a/lib/importers/xml/ddi/question.rb
+++ b/lib/importers/xml/ddi/question.rb
@@ -95,7 +95,7 @@ module Importers::XML::DDI
         extract_urn_identifier(node.at_xpath('./CodeListReference'))
       )
       response_cardinality = node.at_xpath('./ResponseCardinality')
-      if response_cardinality
+      if response_cardinality && cl.response_domain.nil?
         min_responses = response_cardinality['minimumResponses']
         max_responses = response_cardinality['maximumResponses']
         cl.create_response_domain_code(min_responses: min_responses, max_responses: max_responses)


### PR DESCRIPTION
Addresses #312 

There were 3 main issues here for question grids:

* GridDimensions were exporting with incorrect values (using incremental numbers instead of the value linked to a code) and they were giving far too many entries. Fixes 'Incorrect order of response domains in grid.' https://github.com/CLOSER-Cohorts/archivist/issues/312#issuecomment-631556396 
* When there is just one grid dimension then we're not exporting the GridDimension in a manner that will be imported correctly. Fixes 'Code lists not attached to grid' https://github.com/CLOSER-Cohorts/archivist/issues/312#issuecomment-631556396 for the grids with just 1 code from the horizontal code list.
* If there are multiple grid dimensions using cards but there is no response cardinality then no RdsQs are be imported correctly. Fixes 'Code lists not attached to grid' https://github.com/CLOSER-Cohorts/archivist/issues/312#issuecomment-631556396 for the grids with just mulitple codes e.g. qc_F11