### PR TITLE
qv.txt failed when dataset filename is wrong format #428

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -84,7 +84,8 @@ class Dataset < ApplicationRecord
   end
 
   def instance_name
-    return unless filename
-    filename.match(/(\S*).ddi32.rp.xml/)[1]
+    return '' unless filename
+    filename.match(/(\S*).ddi32/)
+    $1.to_s
   end
 end


### PR DESCRIPTION
Addresses #428 

The issue occurs if a dataset file import doesn't match the following format `\S*.ddi32.rp.xml` it was causing the qv.txt to fail as it expects an instance_name for a dataset. The example in #428 had an imported dataset filename as `wchads_07_ph01px.ddi32.rp .xml` (note the space before the .xml) instead of `wchads_07_ph01px.ddi32.rp.xml`.

Ideally we'd log the imports of the datasets like we do with instrument imports and we'd then be able to add a validation for the filename and explain why the import failed however we have no way to display that to the user at the moment. Therefore the current solution is to change the regex to be more accommodating and to make sure that we give a blank string instead of an error when trying to get a dataset instance name