### PR TITLE
Fix migration that was causing instruments page to fail

### DIFF
--- a/db/migrate/20201021193720_add_signed_off_to_instruments.rb
+++ b/db/migrate/20201021193720_add_signed_off_to_instruments.rb
@@ -1,7 +1,7 @@
 class AddSignedOffToInstruments < ActiveRecord::Migration[5.2]
   def change
     unless column_exists? :instruments, :signed_off
-      add_column :instruments, :signed_off, default: false
+      add_column :instruments, :signed_off, :boolean, default: false
     end
   end
 end


### PR DESCRIPTION
Addresses https://github.com/CLOSER-Cohorts/archivist/issues/241 where the instruments page is not loading because the migration did not run.

@spuddybike could we get this on staging asap and run the data migration, let me know if we want me to do that once the staging deploy has taken place.