### PR TITLE
Fix order of Codes in XML export #542

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem 'sass-rails', '5.0.7'
 gem 'sdoc', '1.0.0', group: :doc
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '4.1.18'
+# PostgreSQLCursor for handling large Result Sets
+gem "postgresql_cursor", "~> 0.6.4"
 
 # Production gems
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,8 @@ GEM
     oj (3.3.9)
     orm_adapter (0.5.0)
     pg (0.21.0)
+    postgresql_cursor (0.6.4)
+      activerecord (>= 3.1.0)
     postmark (1.10.0)
       json
       rake
@@ -328,6 +330,7 @@ DEPENDENCIES
   newrelic_rpm (~> 5.4, >= 5.4.0.347)
   oj (= 3.3.9)
   pg (= 0.21.0)
+  postgresql_cursor (~> 0.6.4)
   postmark-rails (= 0.15.0)
   pry-rails (~> 0.3.6)
   puma (= 3.12.6)

--- a/lib/exporters/xml/ddi/code_list.rb
+++ b/lib/exporters/xml/ddi/code_list.rb
@@ -35,7 +35,7 @@ module Exporters::XML::DDI
       }
       urn.add_next_sibling l
       inner_prev = l
-      codelist.codes.find_each do |code|
+      codelist.codes.each_instance do |code|
         co = Nokogiri::XML::Node.new 'l:Code', @doc
         inner_prev.add_next_sibling co
         c_urn = create_urn_node code


### PR DESCRIPTION
.find_each stopped using the order from an association so we're using the postgresql_cursor gem to use their each_instance  which also performs batching on large dataset buts keeps the order of the codes.

Addresses #542