### PR TITLE
Questions not appearing in the export XML #669

### DIFF
--- a/lib/exporters/xml/ddi/instrument.rb
+++ b/lib/exporters/xml/ddi/instrument.rb
@@ -192,11 +192,11 @@ module Exporters::XML::DDI
     end
 
     def question_items
-      @question_items ||= ::QuestionItem.joins(:cc_questions).where('cc_questions.id IN (?)', control_constructs.select{|cc| cc.class == CcQuestion && cc.question_type == 'QuestionItem'}.map(&:id)).distinct
+      @question_items ||= ::QuestionItem.joins(:cc_questions).where('cc_questions.id IN (?)', control_constructs.select{|cc| cc.class.name == 'CcQuestion' && cc.question_type == 'QuestionItem'}.map(&:id)).distinct
     end
 
     def question_grids
-      @question_grids ||= ::QuestionGrid.joins(:cc_questions).where('cc_questions.id IN (?)', control_constructs.select{|cc| cc.class == CcQuestion && cc.question_type == 'QuestionGrid'}.map(&:id)).distinct
+      @question_grids ||= ::QuestionGrid.joins(:cc_questions).where('cc_questions.id IN (?)', control_constructs.select{|cc| cc.class.name == 'CcQuestion' && cc.question_type == 'QuestionGrid'}.map(&:id)).distinct
     end
 
     # Populates the InstrumentScheme with the {::Instrument} details


### PR DESCRIPTION
The issue relates to the fact that we were trying to compare a Class definition, if we change it to comparing a class name string then it will work. The Class definition subtly changes between defining the ExportJob and running the export, which was why it wasn't working beyond the initial export.