### PR TITLE
Show details for instrument import logs

### DIFF
--- a/lib/importers/xml/ddi/category.rb
+++ b/lib/importers/xml/ddi/category.rb
@@ -10,8 +10,13 @@ module Importers::XML::DDI
       rescue
         cat = ::Category.new label: ''
       end
+
       cat.instrument_id = @instrument.id
-      cat.save!
+      begin
+        cat.save!
+      rescue ActiveRecord::RecordInvalid
+        raise Importers::XML::DDI::ValidationError.new(node.to_xml, cat)
+      end
       cat.add_urn extract_urn_identifier node
     end
 

--- a/lib/importers/xml/ddi/code_list.rb
+++ b/lib/importers/xml/ddi/code_list.rb
@@ -28,7 +28,11 @@ module Importers::XML::DDI
         cl = ::CodeList.new label: codes_to_add.map {|c| c.category.label.gsub(/\s*(\S)\S*/, '\1')}.join('_')
       end
       cl.instrument_id = @instrument.id
-      cl.save!
+      begin
+        cl.save!
+      rescue ActiveRecord::RecordInvalid
+        raise Importers::XML::DDI::ValidationError.new(node.to_xml, cl)
+      end
       codes_to_add.each {|c| cl.codes << c}
       cl.add_urn extract_urn_identifier node
     end

--- a/lib/importers/xml/ddi/instruction.rb
+++ b/lib/importers/xml/ddi/instruction.rb
@@ -6,8 +6,11 @@ module Importers::XML::DDI
 
     def XML_node(node)
       instruction = ::Instruction.new({text: node.at_xpath('./InstructionText/LiteralText/Text').content})
-
-      @instrument.instructions << instruction
+      begin
+        @instrument.instructions << instruction
+      rescue ActiveRecord::RecordInvalid
+        raise Importers::XML::DDI::ValidationError.new(node.to_xml, instruction)
+      end
       instruction.add_urn extract_urn_identifier node
     end
 

--- a/lib/importers/xml/ddi/instrument.rb
+++ b/lib/importers/xml/ddi/instrument.rb
@@ -36,7 +36,9 @@ module Importers::XML::DDI
         @instrument.study = options[:study] unless options[:study].to_s.empty?
       rescue => e
         @errors = true
-        log :outcome, "Invalid : #{e.message}"
+        log :input, e.input if e.respond_to?(:input)
+        log :matches, e.record.inspect if e.respond_to?(:record)
+        log :outcome, "Record Invalid : #{e.message}"
         write_to_log
       ensure
         set_import_to_finished

--- a/lib/importers/xml/ddi/question.rb
+++ b/lib/importers/xml/ddi/question.rb
@@ -182,7 +182,11 @@ module Importers::XML::DDI
             extract_urn_identifier(node.at_xpath('./InterviewerInstructionReference'))
         ).try(:id)
       end
-      question.save!
+      begin
+        question.save!
+      rescue ActiveRecord::RecordInvalid
+        raise Importers::XML::DDI::ValidationError.new(node.to_xml, question)
+      end
       question.add_urn extract_urn_identifier node
     end
 

--- a/lib/importers/xml/ddi/validation_error.rb
+++ b/lib/importers/xml/ddi/validation_error.rb
@@ -1,0 +1,12 @@
+
+module Importers::XML::DDI
+  class ValidationError < ActiveRecord::RecordInvalid
+    attr_accessor :input
+
+    def initialize(input = '', record = nil)
+      @input = input
+
+      super(record)
+    end
+  end
+end


### PR DESCRIPTION
Add logging to show XML node and more detailed error message when the Instrument import fails.

<img width="1518" alt="Screenshot 2022-11-09 at 09 36 27" src="https://user-images.githubusercontent.com/13276/200794491-a8c2a43f-5ed8-4c9a-bfb8-7295514c51b4.png">

Addresses #721 