### PR TITLE
Remove inert DV and Topics buttons from Admin Datasets (#881)

### DIFF
--- a/react/src/pages/AdminDatasets.js
+++ b/react/src/pages/AdminDatasets.js
@@ -34,12 +34,6 @@ const AdminDatasets = () => {
           </Link>
         </Button>
         <Button>
-          DV
-        </Button>
-        <Button>
-          Topics
-        </Button>
-        <Button>
           <Link to={url(routes.admin.datasets.importMappings, { datasetId: row.id })}>
             View Imports
           </Link>

--- a/tests/flows/regressions/issue-881-remove-dv-topics-buttons.feature
+++ b/tests/flows/regressions/issue-881-remove-dv-topics-buttons.feature
@@ -1,0 +1,13 @@
+Feature: Remove inert DV and Topics buttons from Admin Datasets (#881)
+  Regression for https://github.com/CLOSER-Cohorts/archivist/issues/881
+  — the DV and Topics buttons on the admin datasets list render nothing
+  interactive and should be removed. The remaining action buttons must
+  still render (verified by table data being present).
+
+  Scenario: DV and Topics buttons are absent from Admin Datasets page
+    When I log in as "simon.reed@browsergroup.com" with password "Password123!"
+    And I navigate to "/admin/datasets"
+    And I wait for the page to settle
+    Then I should see "Rows per page:"
+    And I should not see "DV"
+    And I should not see "Topics"


### PR DESCRIPTION
Removes the two inert DV and Topics buttons from each row on /admin/datasets. Both were literal MUI `<Button>` elements with no link, onClick, or href — clicking them did nothing except trigger a ripple animation. TV and DV data is available from the dataset exports page.

## Round 2 Changes

- Rebased branch onto current `develop` (which had advanced to include #887). The previous submission's diff showed 5 files changed because the merge base had drifted — the extra 4 files were part of #887, not this PR. After rebase, `git diff origin/develop..HEAD --stat` correctly shows exactly 2 files.

## Verification failures from round 1

**FAILED:** Only the two specified files change — `react/src/pages/AdminDatasets.js` and `tests/flows/regressions/issue-881-remove-dv-topics-buttons.feature`.

**Root cause:** The branch was created before #887 was merged to develop. When the verifier compared `origin/develop..HEAD`, the diff included the absence of #887's changes (config/locales/en.yml, lib/importers/txt/mapper/mapping.rb, test/lib/importers/txt/mapper/mapping_test.rb, tests/flows/regressions/issue-887-partial-qv-import-state.feature) as if they were removed by this branch. Rebasing onto current develop resolves this.

## Files changed

- `react/src/pages/AdminDatasets.js` — removes 6 lines (the DV and Topics Button elements)
- `tests/flows/regressions/issue-881-remove-dv-topics-buttons.feature` — new regression feature file

Closes #881