### PR TITLE
Persist filename on Import to survive document cleanup (#889)

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 class Import < ApplicationRecord
-  belongs_to :document
+  belongs_to :document, optional: true
   belongs_to :dataset
   belongs_to :instrument
 
-  delegate :filename, to: :document, allow_nil: true
+  before_create :set_filename
 
-  # Cleanup old documents when import completes successfully
   after_update :cleanup_old_documents, if: :saved_change_to_state?
 
   def parsed_log
@@ -15,6 +14,10 @@ class Import < ApplicationRecord
   end
 
   private
+
+  def set_filename
+    self.filename ||= document&.filename
+  end
 
   def cleanup_old_documents
     # Only cleanup when state changes to completed (not pending)

--- a/app/views/imports/_item.json.jbuilder
+++ b/app/views/imports/_item.json.jbuilder
@@ -2,4 +2,4 @@
 
 json.extract! import, :id, :import_type, :dataset_id, :state
 json.created_at import.created_at.strftime('%a, %e %b %Y %H:%M:%S %z')
-json.filename @documents.find{|doc| doc.id == import.document_id}.try(:filename)
+json.filename import.filename

--- a/db/migrate/20260421155655_add_filename_to_imports.rb
+++ b/db/migrate/20260421155655_add_filename_to_imports.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddFilenameToImports < ActiveRecord::Migration[6.1]
+  def up
+    add_column :imports, :filename, :string
+    execute <<~SQL
+      UPDATE imports
+      SET filename = documents.filename
+      FROM documents
+      WHERE imports.document_id = documents.id
+    SQL
+  end
+
+  def down
+    remove_column :imports, :filename
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1421,7 +1421,8 @@ CREATE TABLE public.imports (
     log text,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    instrument_id integer
+    instrument_id integer,
+    filename character varying
 );
 
 
@@ -3914,7 +3915,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171124115905'),
 ('20171212182936'),
 ('20181106140729'),
-('20190812092806'),
 ('20190812092819'),
 ('20190813092806'),
 ('20190829124508'),
@@ -3924,6 +3924,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240207154741'),
 ('20240208160611'),
 ('20240425130950'),
-('20241124224933');
+('20241124224933'),
+('20260421155655');
 
 

--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class ImportsControllerTest < ActionController::TestCase
+  test "index JSON includes filename for import with no document_id" do
+    doc = Document.create!(filename: 'instrument-data.xml')
+    instrument = Instrument.first || create(:instrument)
+    import = Import.create!(
+      document: doc,
+      dataset: Dataset.first || create(:dataset),
+      instrument: instrument,
+      import_type: 'ImportJob::Instrument',
+      state: 'pending'
+    )
+    Import.where(id: import.id).update_all(document_id: nil)
+
+    get :index, format: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    row = body.find { |r| r['id'] == import.id }
+    assert_not_nil row, "Import not found in response"
+    assert_equal 'instrument-data.xml', row['filename']
+  end
+end

--- a/test/models/import_test.rb
+++ b/test/models/import_test.rb
@@ -8,4 +8,31 @@ class ImportTest < ActiveSupport::TestCase
   test "belongs to an dataset" do
     assert_kind_of Dataset, @import.dataset
   end
+
+  test "stores filename from document at create time" do
+    doc = Document.create!(filename: 'test-file.xml')
+    instrument = Instrument.first || create(:instrument)
+    import = Import.create!(
+      document: doc,
+      dataset: Dataset.first || create(:dataset),
+      instrument: instrument,
+      import_type: 'ImportJob::Instrument',
+      state: 'pending'
+    )
+    assert_equal 'test-file.xml', import.reload.filename
+  end
+
+  test "filename persists after document_id is nullified" do
+    doc = Document.create!(filename: 'historical.xml')
+    instrument = Instrument.first || create(:instrument)
+    import = Import.create!(
+      document: doc,
+      dataset: Dataset.first || create(:dataset),
+      instrument: instrument,
+      import_type: 'ImportJob::Instrument',
+      state: 'pending'
+    )
+    Import.where(id: import.id).update_all(document_id: nil)
+    assert_equal 'historical.xml', import.reload.filename
+  end
 end

--- a/tests/flows/regressions/issue-889-admin-imports-filename.feature
+++ b/tests/flows/regressions/issue-889-admin-imports-filename.feature
@@ -1,0 +1,11 @@
+Feature: Admin Imports page shows filenames for all imports (#889)
+  Regression for https://github.com/CLOSER-Cohorts/archivist/issues/889
+  — the filename column on /admin/imports must show the actual filename
+  for every row, including imports whose document_id has been cleaned up
+  by the after_update hook on Import.
+
+  Scenario: Admin imports page shows filenames not "No document"
+    When I log in as "simon.reed@browsergroup.com" with password "Password123!"
+    And I navigate to "/admin/imports"
+    And I wait for the page to settle
+    Then I should not see "No document"


### PR DESCRIPTION
## Summary

- Adds a `filename` string column to the `imports` table, backfilled from `documents.filename` for all imports whose document is still present
- Adds a `before_create` hook on `Import` to persist the filename at creation time, decoupling it from the document association
- Simplifies `app/views/imports/_item.json.jbuilder` to read `import.filename` directly, removing the `@documents.find` lookup that returned nil once `document_id` was cleaned up
- Preserves the `cleanup_old_documents` after_update callback (intentional storage reclamation) and the React `|| 'No document'` fallback (safety net for legacy rows)

## Test plan

- [ ] Migration runs cleanly: `rails db:migrate` adds the column and backfills existing rows
- [ ] `test/models/import_test.rb`: filename is set at create time and persists after `document_id` is nullified
- [ ] `test/controllers/imports_controller_test.rb`: `/imports.json` returns the correct filename even when `document_id` is nil
- [ ] `tests/flows/regressions/issue-889-admin-imports-filename.feature`: regression flow confirms `/admin/imports` shows no "No document" text for imports with a persisted filename
- [ ] Verify `react/src/pages/AdminImports.js` still contains the `|| 'No document'` fallback unchanged