### PR TITLE
Add bulk interviewee change to instrument constructs page

### DIFF
--- a/.machina/flow-steps/ui.mjs
+++ b/.machina/flow-steps/ui.mjs
@@ -1,0 +1,8 @@
+export default ({ defineStep }) => [
+  defineStep('I select {string} from the {string} dropdown', async (ctx, option, label) => {
+    await ctx.page.getByLabel(label).click();
+    const listbox = ctx.page.locator('[role="listbox"]');
+    await listbox.waitFor({ timeout: 5000 });
+    await listbox.locator('[role="option"]').filter({ hasText: option }).click();
+  }),
+];

--- a/react/src/components/BulkIntervieweeModal.js
+++ b/react/src/components/BulkIntervieweeModal.js
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { get } from 'lodash';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from '@material-ui/core';
+import { CcQuestions } from '../actions';
+
+export const BulkIntervieweeModal = ({ open, onClose, instrumentId }) => {
+  const dispatch = useDispatch();
+  const responseUnits = useSelector(state => get(state.response_units, instrumentId, {}));
+  const ccQuestions = useSelector(state => get(state.cc_questions, instrumentId, {}));
+  const updateStatus = useSelector(state => get(state.statuses, `CcQuestionUpdateAll:${instrumentId}`, {}));
+
+  const [selectedId, setSelectedId] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+
+  const questionCount = Object.keys(ccQuestions).length;
+
+  const handleClose = () => {
+    setSelectedId('');
+    setSuccessMessage('');
+    dispatch({ type: 'CLEAR', payload: { id: instrumentId, type: 'CcQuestionUpdateAll' } });
+    onClose();
+  };
+
+  const handleApply = () => {
+    if (!selectedId) return;
+    setSuccessMessage('');
+    dispatch(
+      CcQuestions.update_all(instrumentId, { response_unit_id: selectedId }, (data) => {
+        setSuccessMessage(data.message);
+        dispatch(CcQuestions.all(instrumentId));
+      })
+    );
+  };
+
+  const errorMessage = updateStatus.error
+    ? (updateStatus.errors?.message || 'An error occurred')
+    : '';
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Change Interviewee</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" gutterBottom>
+          This will update {questionCount} questions.
+        </Typography>
+        {successMessage && (
+          <Typography variant="body2" style={{ color: 'green' }}>
+            {successMessage}
+          </Typography>
+        )}
+        {errorMessage && (
+          <Typography variant="body2" color="error">
+            {errorMessage}
+          </Typography>
+        )}
+        <FormControl fullWidth margin="normal">
+          <InputLabel id="interviewee-label">Interviewee</InputLabel>
+          <Select
+            labelId="interviewee-label"
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+          >
+            {Object.values(responseUnits).map((ru) => (
+              <MenuItem key={ru.id} value={ru.id}>{ru.label}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button
+          onClick={handleApply}
+          color="primary"
+          variant="contained"
+          disabled={!selectedId || updateStatus.saving}
+        >
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/react/src/pages/InstrumentConstructBuild.js
+++ b/react/src/pages/InstrumentConstructBuild.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom';
 import { Instrument, CcConditions, CcLoops, CcSequences, CcStatements, CcQuestions, QuestionItems, QuestionGrids, ResponseUnits, InstrumentTree } from '../actions'
+import { BulkIntervieweeModal } from '../components/BulkIntervieweeModal'
 import { Dashboard } from '../components/Dashboard'
 import { MoveConstructSelect } from '../components/MoveConstructSelect'
 import { CcConditionForm } from '../components/CcConditionForm'
@@ -82,6 +83,7 @@ const Tree = (props) => {
   const [searchString, setSearchString] = useState();
   const [searchFocusIndex, setSearchFocusIndex] = useState();
   const [searchFoundCount, setSearchFoundCount] = useState();
+  const [bulkIntervieweeOpen, setBulkIntervieweeOpen] = useState(false);
 
   // Case insensitive search of `node.title`
   const customSearchMethod = ({ node, searchQuery }) =>
@@ -238,7 +240,13 @@ const Tree = (props) => {
           <ButtonGroup color="primary" aria-label="outlined primary button group">
             <Button onClick={() => { toggleExpand(true) }} startIcon={<ExpandMoreIcon />}>Expand All</Button>
             <Button onClick={() => { toggleExpand(false) }} startIcon={<ExpandLessIcon />}>Collapse All</Button>
+            <Button onClick={() => { setBulkIntervieweeOpen(true) }}>Change Interviewee</Button>
           </ButtonGroup>
+          <BulkIntervieweeModal
+            open={bulkIntervieweeOpen}
+            onClose={() => setBulkIntervieweeOpen(false)}
+            instrumentId={instrumentId}
+          />
         </Grid>
       </Grid>
 

--- a/tests/flows/regressions/issue-879-bulk-interviewee-change.feature
+++ b/tests/flows/regressions/issue-879-bulk-interviewee-change.feature
@@ -1,0 +1,23 @@
+Feature: Bulk change Interviewee on instrument constructs page (#879)
+  Feature request: from the Build > Constructs page, an admin can
+  change the Interviewee (ResponseUnit) on every question in the
+  instrument in a single operation.
+
+  Background:
+    Given I log in as "simon.reed@browsergroup.com" with password "Password123!"
+
+  Scenario: Button is visible and opens the bulk-change modal
+    When I navigate to "/instruments/mcs_12_co/build/constructs"
+    And I wait for the page to settle
+    Then I should see "Expand All"
+    And I should see "Collapse All"
+    And I should see "Change Interviewee"
+
+  Scenario: Submitting the modal updates every question
+    When I navigate to "/instruments/mcs_12_co/build/constructs"
+    And I wait for the page to settle
+    And I click the "Change Interviewee" button
+    And I select "Main parent of cohort/sample member" from the "Interviewee" dropdown
+    And I click the "Apply" button
+    And I wait for the page to settle
+    Then I should see "11 questions updated successfully"


### PR DESCRIPTION
## Summary

- Adds a "Change Interviewee" button to the Expand/Collapse ButtonGroup on `/instruments/:prefix/build/constructs`
- Clicking opens a dialog with a preview count ("This will update N questions"), a ResponseUnit dropdown, and Apply/Cancel buttons
- Submitting calls the existing `PUT /instruments/:id/cc_questions/update_all.json` endpoint to update every question at once
- On success, re-fetches CcQuestions so the tree reflects the new ResponseUnit on every node

Closes #879

## Test plan

- [x] Flow test `tests/flows/regressions/issue-879-bulk-interviewee-change.feature` — both scenarios green
- [x] Scenario 1: "Change Interviewee" button visible next to Expand All / Collapse All
- [x] Scenario 2: Selecting a ResponseUnit and clicking Apply updates all questions and shows confirmation