### PR TITLE
Wire up trash icon to remove code list options (#888)

### DIFF
--- a/.machina/flow-steps/code_list.mjs
+++ b/.machina/flow-steps/code_list.mjs
@@ -19,6 +19,14 @@ export default ({ defineStep }) => [
     await item.click();
   }),
 
+  // Targets the SVG directly so the step works on both patched (IconButton) and
+  // unpatched (plain span) code — on unpatched, the click is a no-op and the row stays.
+  defineStep('I click the first trash icon on the code list', async (ctx) => {
+    const icon = ctx.page.locator('table tbody tr:first-child td:last-child svg').first();
+    await icon.waitFor({ timeout: 5000 });
+    await icon.click();
+  }),
+
   // Adds a new code row, fills in value and label (via autocomplete), and selects the matching option.
   // Requires the instrument to have a category with the given label already loaded.
   defineStep('I add a code with value {string} and label {string}', async (ctx, value, label) => {

--- a/.machina/flow-steps/code_list.mjs
+++ b/.machina/flow-steps/code_list.mjs
@@ -1,0 +1,36 @@
+export default ({ defineStep }) => [
+  // Asserts that an <input> or <textarea> on the page has the given display value.
+  // Use this when the value is rendered in a form field rather than as a visible text node.
+  defineStep('I should see input with value {string}', async (ctx, value) => {
+    await ctx.page.waitForFunction(
+      (v) => {
+        const inputs = document.querySelectorAll('input, textarea');
+        return Array.from(inputs).some(el => el.value === v);
+      },
+      value,
+      { timeout: 10000 }
+    );
+  }),
+
+  // Clicks a named item in the BuildContainer list (MUI ListItemText — not a button or link).
+  defineStep('I click on the list item {string}', async (ctx, text) => {
+    const item = ctx.page.locator('li').filter({ hasText: text }).first();
+    await item.waitFor({ timeout: 5000 });
+    await item.click();
+  }),
+
+  // Adds a new code row, fills in value and label (via autocomplete), and selects the matching option.
+  // Requires the instrument to have a category with the given label already loaded.
+  defineStep('I add a code with value {string} and label {string}', async (ctx, value, label) => {
+    await ctx.page.locator('button[aria-label="Add code"]').click();
+    await ctx.page.waitForTimeout(500);
+
+    const valueInputs = ctx.page.locator('textarea[name*=".value"]');
+    await valueInputs.last().fill(value);
+
+    const labelInputs = ctx.page.locator('input[name*=".label"]');
+    await labelInputs.last().fill(label);
+    await ctx.page.waitForSelector('[role="listbox"]', { timeout: 5000 });
+    await ctx.page.locator('[role="option"]').filter({ hasText: new RegExp('^' + label + '$') }).first().click();
+  }),
+];

--- a/react/src/components/CodeListForm.js
+++ b/react/src/components/CodeListForm.js
@@ -31,6 +31,7 @@ import {
   Grid,
   Button,
   CssBaseline,
+  IconButton,
 } from '@material-ui/core';
 
 
@@ -231,12 +232,13 @@ export const CodeListForm = (props) => {
                                     </TableCell>
                                     <TableCell className={classes.small}>
                                       {instrument && !instrument.signed_off && (
-                                        <span
-                                          onClick={() => {}}
-                                          style={{ cursor: 'pointer' }}
+                                        <IconButton
+                                          aria-label={`Delete code ${fields.value[index].value}`}
+                                          onClick={() => fields.remove(index)}
+                                          size="small"
                                         >
                                           <DeleteIcon />
-                                        </span>
+                                        </IconButton>
                                       )}
                                     </TableCell>
                                   </TableRow>

--- a/react/src/components/CodeListForm.js
+++ b/react/src/components/CodeListForm.js
@@ -156,7 +156,9 @@ export const CodeListForm = (props) => {
                 ))}
                 <h3>Codes</h3>
                 {instrument && !instrument.signed_off && (
-                  <AddCircleOutlineIcon onClick={() => push('codes', {})}/>
+                  <IconButton aria-label="Add code" onClick={() => push('codes', {})}>
+                    <AddCircleOutlineIcon />
+                  </IconButton>
                 )}
                 <TableContainer component={Paper}>
                   <Table className={classes.table} aria-label="simple table">

--- a/tests/flows/regressions/issue-888-code-list-option-delete.feature
+++ b/tests/flows/regressions/issue-888-code-list-option-delete.feature
@@ -1,0 +1,16 @@
+Feature: Trash icon removes a code list option (#888)
+  Regression for https://github.com/CLOSER-Cohorts/archivist/issues/888
+  — clicking the trash icon next to a code option must remove the row
+  from the form, and saving must persist the deletion.
+
+  Scenario: Trash icon removes a code from an existing code list
+    When I log in as "simon.reed@browsergroup.com" with password "Password123!"
+    And I navigate to "/instruments/nshd_61_ci/build/code_lists/43875"
+    And I wait for the page to settle
+    And I should see "213050"
+    And I click the "Delete code 1" button
+    And I click the "Save" button
+    And I wait for the page to settle
+    And I navigate to "/instruments/nshd_61_ci/build/code_lists/43875"
+    And I wait for the page to settle
+    Then I should not see "213050"

--- a/tests/flows/regressions/issue-888-code-list-option-delete.feature
+++ b/tests/flows/regressions/issue-888-code-list-option-delete.feature
@@ -3,14 +3,61 @@ Feature: Trash icon removes a code list option (#888)
   — clicking the trash icon next to a code option must remove the row
   from the form, and saving must persist the deletion.
 
-  Scenario: Trash icon removes a code from an existing code list
-    When I log in as "simon.reed@browsergroup.com" with password "Password123!"
-    And I navigate to "/instruments/nshd_61_ci/build/code_lists/43875"
+  Background:
+    Given I log in as "simon.reed@browsergroup.com" with password "Password123!"
+
+  Scenario: Trash icon removes a saved code via direct URL
+    When I navigate to "/instruments/ns_09_w6/build/code_lists/90968"
     And I wait for the page to settle
-    And I should see "213050"
+    And I should see "460306"
     And I click the "Delete code 1" button
     And I click the "Save" button
     And I wait for the page to settle
-    And I navigate to "/instruments/nshd_61_ci/build/code_lists/43875"
+    And I navigate to "/instruments/ns_09_w6/build/code_lists/90968"
     And I wait for the page to settle
-    Then I should not see "213050"
+    Then I should not see "460306"
+
+  Scenario: Trashing two saved codes in one save deletes both server-side
+    When I navigate to "/instruments/ns_09_w6/build/code_lists/90970"
+    And I wait for the page to settle
+    And I should see "460307"
+    And I should see "460308"
+    And I click the "Delete code 3" button
+    And I click the "Delete code 4" button
+    And I click the "Save" button
+    And I wait for the page to settle
+    And I navigate to "/instruments/ns_09_w6/build/code_lists/90970"
+    And I wait for the page to settle
+    Then I should not see "460307"
+    And I should not see "460308"
+
+  Scenario: Delete-then-readd saves cleanly without constraint conflict
+    When I navigate to "/instruments/ns_09_w6/build/code_lists/90971"
+    And I wait for the page to settle
+    And I should see "460309"
+    And I click the "Delete code 1" button
+    And I add a code with value "1" and label "Yes"
+    And I click the "Save" button
+    And I wait for the page to settle
+    And I navigate to "/instruments/ns_09_w6/build/code_lists/90971"
+    And I wait for the page to settle
+    Then I should see input with value "Yes"
+
+  Scenario: Trashing a newly added unsaved row discards it locally without server call
+    When I navigate to "/instruments/ns_09_w6/build/code_lists/90972"
+    And I wait for the page to settle
+    And I should see "459167"
+    And I click the "Add code" button
+    And I click the "Delete code undefined" button
+    And I click the "Save" button
+    And I wait for the page to settle
+    Then I should see "459167"
+
+  Scenario: Feature is reachable via standard navigation from the instrument build page
+    When I navigate to "/instruments/ns_09_w6/build"
+    And I wait for the page to settle
+    And I click the "Code Lists" link
+    And I wait for the page to settle
+    And I click on the list item "cs_NVQSub"
+    And I wait for the page to settle
+    Then the URL should match "/instruments/ns_09_w6/build/code_lists/90968"

--- a/tests/flows/regressions/issue-888-code-list-option-delete.feature
+++ b/tests/flows/regressions/issue-888-code-list-option-delete.feature
@@ -9,32 +9,32 @@ Feature: Trash icon removes a code list option (#888)
   Scenario: Trash icon removes a saved code via direct URL
     When I navigate to "/instruments/ns_09_w6/build/code_lists/90968"
     And I wait for the page to settle
-    And I should see "460306"
-    And I click the "Delete code 1" button
+    And I should see "459144"
+    And I click the first trash icon on the code list
     And I click the "Save" button
     And I wait for the page to settle
     And I navigate to "/instruments/ns_09_w6/build/code_lists/90968"
     And I wait for the page to settle
-    Then I should not see "460306"
+    Then I should not see "459144"
 
   Scenario: Trashing two saved codes in one save deletes both server-side
     When I navigate to "/instruments/ns_09_w6/build/code_lists/90970"
     And I wait for the page to settle
-    And I should see "460307"
-    And I should see "460308"
-    And I click the "Delete code 3" button
-    And I click the "Delete code 4" button
+    And I should see "459156"
+    And I should see "459157"
+    And I click the "Delete code 1" button
+    And I click the "Delete code 2" button
     And I click the "Save" button
     And I wait for the page to settle
     And I navigate to "/instruments/ns_09_w6/build/code_lists/90970"
     And I wait for the page to settle
-    Then I should not see "460307"
-    And I should not see "460308"
+    Then I should not see "459156"
+    And I should not see "459157"
 
   Scenario: Delete-then-readd saves cleanly without constraint conflict
     When I navigate to "/instruments/ns_09_w6/build/code_lists/90971"
     And I wait for the page to settle
-    And I should see "460309"
+    And I should see "460310"
     And I click the "Delete code 1" button
     And I add a code with value "1" and label "Yes"
     And I click the "Save" button


### PR DESCRIPTION
## Summary

- Fixes the trash icon next to each code option on the code-list edit page — it was wired to \`onClick={() => {}}\` (a no-op) and never removed the row.
- Replaces the \`<span>\` with \`<IconButton>\` (accessible \`role="button"\`, value-specific \`aria-label\`) and wires \`onClick\` to \`fields.remove(index)\`.
- Wraps the Add code icon in \`<IconButton aria-label="Add code">\` so the flow runner can target it consistently.
- The backend already handled deletion via \`accepts_nested_attributes_for :codes\` with \`allow_destroy: true\` — no backend changes needed.

## Round 3 Changes

Round 2 was returned with one failing sign-off criterion:

**No red-run artifact.** The test was added in a commit after the fix, so it was only ever run against patched code. The gate requires evidence the \`I should not see\` assertion actually detects the bug on un-patched code (exit 22).

Changes in this round:
- **Refreshed test data** — codes 460306–460309 were consumed by the round 2 green run. Updated all code IDs to currently-present records (459144, 459156/459157, 460310, 459167).
- **Added generic trash-icon click step** — \`I click the first trash icon on the code list\` targets \`table tbody tr:first-child td:last-child svg\`. Works on both patched (IconButton) and un-patched (plain span) code, so scenario 1 reaches \`I should not see\` on un-patched code.
- **Red run demonstrated** — ran against un-patched server (main archivist at commit 30000d1b). Exit 22, failing at \`I should not see "459144"\` — code persisted because the trash click was a no-op. Screenshot at artifact 1849.
- **Green run confirmed** — all 5 scenarios pass on patched code (exit 0). Red session log: artifact 1850. Green session log: artifact 1851.

## Test plan

- [x] Regression: \`tests/flows/regressions/issue-888-code-list-option-delete.feature\` — 5 scenarios, all pass
- [x] Red run on un-patched code: exit 22, \`I should not see "459144"\` fails (artifact 1850)
- [x] Green run on patched code: exit 0, all 5 scenarios pass (artifact 1851)
- [x] Single-code delete persists after save and re-navigation
- [x] Multi-code delete in one save deletes both server-side
- [x] Delete-then-readd saves without constraint conflict
- [x] Trashing an unsaved row discards it locally (no server call)
- [x] Navigation path: build page → Code Lists → list item → correct URL